### PR TITLE
Don't show increment / decrement buttons (+/-) when integer param ReadOnly

### DIFF
--- a/app/components/float-control.hbs
+++ b/app/components/float-control.hbs
@@ -117,6 +117,8 @@
                         {{ on "change" this.update }} 
                         {{ style this.customizeStyles }}
                     />
+                    {{#if @control.readOnly}}
+                    {{else}}                    
                     <button class="increment" 
                         {{ on "click" this.increment}} 
                         disabled={{ @control.readOnly}}
@@ -125,6 +127,7 @@
                         {{ on "click" this.decrement}}
                         disabled={{ @control.readOnly}}
                     >-</button>
+                    {{/if}}
                 {{/if}}
             {{/if}}
         {{/if}}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/636694/169908458-827af559-f2ed-4e4e-9651-48d394c8b5dd.png)

Checking the @control.readOnly to decide whether to add the +/- buttons.

However in Chataigne dashboard the buttons are simply darkened when readOnly:
![image](https://user-images.githubusercontent.com/636694/169909065-96a92fce-769e-4cf4-ab2f-1321c382354a.png)
